### PR TITLE
fix of build bug

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -17,6 +17,7 @@ RUN pip3 install uwsgi
 # Copy and Install requirements
 # (before copying the rest of the code, so docker would cache them and not reinstall)
 WORKDIR $BACKENDDIR
+RUN apt-get install -y libssl-dev
 COPY requirements.txt .
 RUN pip3 install -r requirements.txt
 


### PR DESCRIPTION
Bug Fix: 
docker-compose build fails at 
"pycurl.h:164:13: fatal error: openssl/ssl.h: No such file or directory
# include <openssl/ssl.h>"