### PR TITLE
Fixed docker build issue while setting tzdata

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER Ray Alez
 ENV HOMEDIR=/home
 ENV PROJECTDIR=/home/blog
 ENV BACKENDDIR=/home/blog/backend
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Install basic apps
 RUN apt-get update && apt-get install -y git emacs curl iputils-ping


### PR DESCRIPTION
During docker-compose running, there is an interaction with the terminal for the time zone that is not interactable due to some reason. It is causing a build failure.

Please select the geographic area in which you live. Subsequent configuration
questions will narrow this down by presenting a list of cities, representing
the time zones in which they are located.
1. Africa      4. Australia  7. Atlantic  10. Pacific  13. Etc
2. America     5. Arctic     8. Europe    11. SystemV
3. Antarctica  6. Asia       9. Indian    12. US
Geographic area: